### PR TITLE
fix sorting of time columns

### DIFF
--- a/src/model/task.cpp
+++ b/src/model/task.cpp
@@ -509,13 +509,13 @@ QVariant Task::data(int column, int role) const
                 case 0:
                     return m_name;
                 case 1:
-                    return QVariant::fromValue<int64_t>(m_sessionTime);
+                    return QVariant::fromValue<qlonglong>(m_sessionTime);
                 case 2:
-                    return QVariant::fromValue<int64_t>(m_time);
+                    return QVariant::fromValue<qlonglong>(m_time);
                 case 3:
-                    return QVariant::fromValue<int64_t>(m_totalSessionTime);
+                    return QVariant::fromValue<qlonglong>(m_totalSessionTime);
                 case 4:
-                    return QVariant::fromValue<int64_t>(m_totalTime);
+                    return QVariant::fromValue<qlonglong>(m_totalTime);
                 case 5:
                     return QVariant::fromValue<int>(m_priority);
                 case 6:


### PR DESCRIPTION
Commit 910b2939a07ee241 changed QVariant types for sorting from qlonglong
to int64_t, but QSortFilterProxyModel::lessThan() docs explicitly list
types that are compared numerically, int64_t is not one of them, so it
gets sorted as a string. This meant that '0:02' was sorted before '0:17'.