### PR TITLE
Added daily reports

### DIFF
--- a/src/base/reportcriteria.h
+++ b/src/base/reportcriteria.h
@@ -53,6 +53,19 @@ public:
          * Export the history of all events as csv
          */
         CSVEventLogExport = 3,
+        /**
+         * Daily report: tasks with comments and time for a given day.
+         */
+        DailyReport = 4,
+        /**
+         * Period report: tasks with comments and total time for an arbitrary date range.
+         */
+        PeriodReport = 5,
+        /**
+         * Period daily report: per-day breakdown of tasks with comments and time,
+         * day totals, and grand total for the date range.
+         */
+        PeriodDailyReport = 6,
     };
 
     /**

--- a/src/dialogs/exportdialog.cpp
+++ b/src/dialogs/exportdialog.cpp
@@ -46,6 +46,9 @@ ExportDialog::ExportDialog(QWidget *parent, TaskView *taskView)
     connect(ui.radioHistoryCsv, &QRadioButton::toggled, this, &ExportDialog::updateUI);
     connect(ui.radioEventLogCsv, &QRadioButton::toggled, this, &ExportDialog::updateUI);
     connect(ui.radioTimesText, &QRadioButton::toggled, this, &ExportDialog::updateUI);
+    connect(ui.radioDailyReport, &QRadioButton::toggled, this, &ExportDialog::updateUI);
+    connect(ui.radioPeriodReport, &QRadioButton::toggled, this, &ExportDialog::updateUI);
+    connect(ui.radioPeriodDailyReport, &QRadioButton::toggled, this, &ExportDialog::updateUI);
     connect(ui.radioComma, &QRadioButton::toggled, this, &ExportDialog::updateUI);
     connect(ui.radioSemicolon, &QRadioButton::toggled, this, &ExportDialog::updateUI);
     connect(ui.radioOther, &QRadioButton::toggled, this, &ExportDialog::updateUI);
@@ -94,7 +97,7 @@ void ExportDialog::exportToFile()
 ReportCriteria ExportDialog::reportCriteria()
 {
     rc.from = ui.dtFrom->date();
-    rc.to = ui.dtTo->date();
+    rc.to = (rc.reportType == ReportCriteria::DailyReport) ? rc.from : ui.dtTo->date();
     rc.decimalMinutes = (ui.combodecimalminutes->currentText() == i18nc("format to display times", "Decimal"));
     qCDebug(KTT_LOG) << "rc.decimalMinutes is" << rc.decimalMinutes;
 
@@ -131,6 +134,12 @@ void ExportDialog::updateUI()
         rt = ReportCriteria::CSVEventLogExport;
     } else if (ui.radioTimesText->isChecked()) {
         rt = ReportCriteria::TextTotalsExport;
+    } else if (ui.radioDailyReport->isChecked()) {
+        rt = ReportCriteria::DailyReport;
+    } else if (ui.radioPeriodReport->isChecked()) {
+        rt = ReportCriteria::PeriodReport;
+    } else if (ui.radioPeriodDailyReport->isChecked()) {
+        rt = ReportCriteria::PeriodDailyReport;
     } else {
         qCWarning(KTT_LOG) << "*** ExportDialog::updateUI: Unexpected report type choice";
         rt = ReportCriteria::TextTotalsExport;
@@ -140,8 +149,20 @@ void ExportDialog::updateUI()
     switch (rt) {
     case ReportCriteria::CSVHistoryExport:
     case ReportCriteria::CSVEventLogExport:
+    case ReportCriteria::PeriodReport:
+    case ReportCriteria::PeriodDailyReport:
         ui.grpDateRange->setEnabled(true);
         ui.grpDateRange->show();
+        ui.textLabel1->setText(i18n("From:"));
+        ui.dtTo->show();
+        ui.textLabel1_2->show();
+        break;
+    case ReportCriteria::DailyReport:
+        ui.grpDateRange->setEnabled(true);
+        ui.grpDateRange->show();
+        ui.textLabel1->setText(i18n("Date:"));
+        ui.dtTo->hide();
+        ui.textLabel1_2->hide();
         break;
     case ReportCriteria::TextTotalsExport:
     case ReportCriteria::CSVTotalsExport:

--- a/src/dialogs/exportdialog.ui
+++ b/src/dialogs/exportdialog.ui
@@ -113,6 +113,27 @@ SPDX-License-Identifier: GPL-2.0-or-later
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QRadioButton" name="radioDailyReport">
+        <property name="text">
+         <string>Daily Report as Text</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioPeriodReport">
+        <property name="text">
+         <string>Period Report as Text</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioPeriodDailyReport">
+        <property name="text">
+         <string>Period Daily Report as Text</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/export/CMakeLists.txt
+++ b/src/export/CMakeLists.txt
@@ -6,7 +6,10 @@ target_sources(ktt-export
     csveventlog.cpp csveventlog.h
     csvhistory.cpp csvhistory.h
     csvtotals.cpp csvtotals.h
+    dailyreport.cpp dailyreport.h
     export.cpp export.h
+    perioddailyreport.cpp perioddailyreport.h
+    periodreport.cpp periodreport.h
     totalsastext.cpp totalsastext.h
 )
 

--- a/src/export/dailyreport.cpp
+++ b/src/export/dailyreport.cpp
@@ -1,0 +1,121 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "dailyreport.h"
+
+#include <QMap>
+
+#include <KLocalizedString>
+
+#include "base/ktimetrackerutility.h"
+#include "model/eventsmodel.h"
+#include "model/projectmodel.h"
+#include "model/task.h"
+#include "model/tasksmodel.h"
+
+struct CommentEntry {
+    QString text;
+    int64_t seconds = 0;
+};
+
+struct TaskDayData {
+    QString name;
+    int64_t totalSeconds = 0;
+    QList<CommentEntry> comments;
+};
+
+QString exportDailyReportToString(ProjectModel *projectModel, const ReportCriteria &rc)
+{
+    const QDate reportDate = rc.from;
+    const QString cr = QStringLiteral("\n");
+
+    // Collect data: group events by task UID for the given day
+    QMap<QString, TaskDayData> taskDataMap;
+
+    for (const Event *event : projectModel->eventsModel()->events()) {
+        if (!event->hasEndDate()) {
+            continue; // skip currently running timers
+        }
+
+        if (event->dtStart().date() != reportDate) {
+            continue;
+        }
+
+        const QString taskUid = event->relatedTo();
+        if (taskUid.isEmpty()) {
+            continue;
+        }
+
+        Task *task = dynamic_cast<Task *>(projectModel->tasksModel()->taskByUID(taskUid));
+        if (!task) {
+            continue;
+        }
+
+        TaskDayData &data = taskDataMap[taskUid];
+        if (data.name.isEmpty()) {
+            // Build full task name including parent chain
+            QString fullName = task->name();
+            Task *parent = task->parentTask();
+            while (parent) {
+                fullName = parent->name() + QStringLiteral(" -> ") + fullName;
+                parent = parent->parentTask();
+            }
+            data.name = fullName;
+        }
+
+        const int64_t durationSecs = event->dtEnd().toSecsSinceEpoch() - event->dtStart().toSecsSinceEpoch();
+        if (durationSecs > 0) {
+            data.totalSeconds += durationSecs;
+        }
+
+        // Use only the last comment — earlier entries are previous edit versions
+        const QStringList eventComments = event->comments();
+        if (!eventComments.isEmpty()) {
+            const QString comment = eventComments.last().trimmed();
+            if (!comment.isEmpty()) {
+                data.comments.append({comment, durationSecs > 0 ? durationSecs : 0});
+            }
+        }
+    }
+
+    // Build report string
+    QString report;
+
+    const QString title = i18n("Daily Report — %1", QLocale().toString(reportDate, QLocale::LongFormat));
+    report += title + cr;
+    report += QString(title.length(), QChar::fromLatin1('=')) + cr + cr;
+
+    if (taskDataMap.isEmpty()) {
+        report += i18n("No tasks recorded for this day.") + cr;
+        return report;
+    }
+
+    int64_t grandTotalSeconds = 0;
+
+    for (const TaskDayData &data : taskDataMap) {
+        const double minutes = static_cast<double>(data.totalSeconds) / 60.0;
+        report += i18n("Task: %1", data.name) + cr;
+        report += QStringLiteral("  ") + i18n("Time: %1", formatTime(minutes, rc.decimalMinutes)) + cr;
+
+        if (!data.comments.isEmpty()) {
+            report += QStringLiteral("  ") + i18n("Comments:") + cr;
+            for (const CommentEntry &c : data.comments) {
+                const double mins = static_cast<double>(c.seconds) / 60.0;
+                report += QStringLiteral("    - ") + c.text
+                    + QStringLiteral(" [") + formatTime(mins, rc.decimalMinutes) + QStringLiteral("]") + cr;
+            }
+        }
+
+        report += cr;
+        grandTotalSeconds += data.totalSeconds;
+    }
+
+    const double totalMinutes = static_cast<double>(grandTotalSeconds) / 60.0;
+    report += QString(40, QChar::fromLatin1('-')) + cr;
+    report += i18n("Total: %1", formatTime(totalMinutes, rc.decimalMinutes)) + cr;
+
+    return report;
+}

--- a/src/export/dailyreport.h
+++ b/src/export/dailyreport.h
@@ -1,0 +1,25 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef DAILYREPORT_H
+#define DAILYREPORT_H
+
+#include <QString>
+
+#include "base/reportcriteria.h"
+
+class ProjectModel;
+
+/**
+ * Generate a daily report as plain text.
+ *
+ * The report lists all tasks that have recorded time on rc.from date,
+ * showing the task name, all associated comments, and the time spent.
+ * A total time line is appended at the end.
+ */
+QString exportDailyReportToString(ProjectModel *projectModel, const ReportCriteria &rc);
+
+#endif // DAILYREPORT_H

--- a/src/export/export.cpp
+++ b/src/export/export.cpp
@@ -12,6 +12,9 @@
 #include "csveventlog.h"
 #include "csvhistory.h"
 #include "csvtotals.h"
+#include "dailyreport.h"
+#include "perioddailyreport.h"
+#include "periodreport.h"
 #include "ktt_debug.h"
 #include "model/projectmodel.h"
 #include "totalsastext.h"
@@ -27,6 +30,12 @@ QString exportToString(ProjectModel *model, Task *currentTask, const ReportCrite
         return exportCSVEventLogToString(model, rc);
     case ReportCriteria::TextTotalsExport:
         return totalsAsText(model->tasksModel(), currentTask, rc);
+    case ReportCriteria::DailyReport:
+        return exportDailyReportToString(model, rc);
+    case ReportCriteria::PeriodReport:
+        return exportPeriodReportToString(model, rc);
+    case ReportCriteria::PeriodDailyReport:
+        return exportPeriodDailyReportToString(model, rc);
     default:
         return QString();
     }

--- a/src/export/perioddailyreport.cpp
+++ b/src/export/perioddailyreport.cpp
@@ -1,0 +1,141 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "perioddailyreport.h"
+
+#include <QMap>
+
+#include <KLocalizedString>
+
+#include "base/ktimetrackerutility.h"
+#include "model/eventsmodel.h"
+#include "model/projectmodel.h"
+#include "model/task.h"
+#include "model/tasksmodel.h"
+
+struct CommentEntry {
+    QString text;
+    int64_t seconds = 0;
+};
+
+struct TaskDayEntry {
+    QString name;
+    int64_t totalSeconds = 0;
+    QList<CommentEntry> comments;
+};
+
+// date -> (taskUid -> entry)
+using DayMap = QMap<QDate, QMap<QString, TaskDayEntry>>;
+
+QString exportPeriodDailyReportToString(ProjectModel *projectModel, const ReportCriteria &rc)
+{
+    const QDate fromDate = rc.from;
+    const QDate toDate = rc.to;
+    const QString cr = QStringLiteral("\n");
+
+    DayMap dayMap;
+
+    for (const Event *event : projectModel->eventsModel()->events()) {
+        if (!event->hasEndDate()) {
+            continue; // skip currently running timers
+        }
+
+        const QDate eventDate = event->dtStart().date();
+        if (eventDate < fromDate || eventDate > toDate) {
+            continue;
+        }
+
+        const QString taskUid = event->relatedTo();
+        if (taskUid.isEmpty()) {
+            continue;
+        }
+
+        Task *task = dynamic_cast<Task *>(projectModel->tasksModel()->taskByUID(taskUid));
+        if (!task) {
+            continue;
+        }
+
+        TaskDayEntry &entry = dayMap[eventDate][taskUid];
+        if (entry.name.isEmpty()) {
+            QString fullName = task->name();
+            Task *parent = task->parentTask();
+            while (parent) {
+                fullName = parent->name() + QStringLiteral(" -> ") + fullName;
+                parent = parent->parentTask();
+            }
+            entry.name = fullName;
+        }
+
+        const int64_t durationSecs = event->dtEnd().toSecsSinceEpoch() - event->dtStart().toSecsSinceEpoch();
+        if (durationSecs > 0) {
+            entry.totalSeconds += durationSecs;
+        }
+
+        // Use only the last comment — earlier entries are previous edit versions
+        const QStringList eventComments = event->comments();
+        if (!eventComments.isEmpty()) {
+            const QString comment = eventComments.last().trimmed();
+            if (!comment.isEmpty()) {
+                entry.comments.append({comment, durationSecs > 0 ? durationSecs : 0});
+            }
+        }
+    }
+
+    // Build report string
+    QString report;
+
+    const QString title = i18n("Period Daily Report — %1 – %2",
+                                QLocale().toString(fromDate, QLocale::ShortFormat),
+                                QLocale().toString(toDate, QLocale::ShortFormat));
+    report += title + cr;
+    report += QString(title.length(), QChar::fromLatin1('=')) + cr + cr;
+
+    if (dayMap.isEmpty()) {
+        report += i18n("No tasks recorded for this period.") + cr;
+        return report;
+    }
+
+    int64_t grandTotalSeconds = 0;
+
+    for (auto dayIt = dayMap.cbegin(); dayIt != dayMap.cend(); ++dayIt) {
+        const QDate date = dayIt.key();
+        const QMap<QString, TaskDayEntry> &tasks = dayIt.value();
+
+        const QString dayHeader = QLocale().toString(date, QLocale::LongFormat);
+        report += dayHeader + cr;
+        report += QString(dayHeader.length(), QChar::fromLatin1('-')) + cr;
+
+        int64_t dayTotalSeconds = 0;
+
+        for (const TaskDayEntry &entry : tasks) {
+            const double minutes = static_cast<double>(entry.totalSeconds) / 60.0;
+            report += i18n("Task: %1", entry.name) + cr;
+            report += QStringLiteral("  ") + i18n("Time: %1", formatTime(minutes, rc.decimalMinutes)) + cr;
+
+            if (!entry.comments.isEmpty()) {
+                report += QStringLiteral("  ") + i18n("Comments:") + cr;
+                for (const CommentEntry &c : entry.comments) {
+                    const double mins = static_cast<double>(c.seconds) / 60.0;
+                    report += QStringLiteral("    - ") + c.text
+                        + QStringLiteral(" [") + formatTime(mins, rc.decimalMinutes) + QStringLiteral("]") + cr;
+                }
+            }
+
+            report += cr;
+            dayTotalSeconds += entry.totalSeconds;
+        }
+
+        const double dayMinutes = static_cast<double>(dayTotalSeconds) / 60.0;
+        report += i18n("Day total: %1", formatTime(dayMinutes, rc.decimalMinutes)) + cr + cr;
+        grandTotalSeconds += dayTotalSeconds;
+    }
+
+    const double totalMinutes = static_cast<double>(grandTotalSeconds) / 60.0;
+    report += QString(40, QChar::fromLatin1('=')) + cr;
+    report += i18n("Total: %1", formatTime(totalMinutes, rc.decimalMinutes)) + cr;
+
+    return report;
+}

--- a/src/export/perioddailyreport.h
+++ b/src/export/perioddailyreport.h
@@ -1,0 +1,26 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef PERIODDAILYREPORT_H
+#define PERIODDAILYREPORT_H
+
+#include <QString>
+
+#include "base/reportcriteria.h"
+
+class ProjectModel;
+
+/**
+ * Generate a period daily report as plain text.
+ *
+ * The report covers the [rc.from, rc.to] date range. For each day that has
+ * recorded time, it lists all tasks with their comments and time spent that
+ * day, followed by a day total. A grand total for the whole period is
+ * appended at the end.
+ */
+QString exportPeriodDailyReportToString(ProjectModel *projectModel, const ReportCriteria &rc);
+
+#endif // PERIODDAILYREPORT_H

--- a/src/export/periodreport.cpp
+++ b/src/export/periodreport.cpp
@@ -1,0 +1,125 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "periodreport.h"
+
+#include <QMap>
+
+#include <KLocalizedString>
+
+#include "base/ktimetrackerutility.h"
+#include "model/eventsmodel.h"
+#include "model/projectmodel.h"
+#include "model/task.h"
+#include "model/tasksmodel.h"
+
+struct CommentEntry {
+    QString text;
+    int64_t seconds = 0;
+};
+
+struct TaskPeriodData {
+    QString name;
+    int64_t totalSeconds = 0;
+    QList<CommentEntry> comments;
+};
+
+QString exportPeriodReportToString(ProjectModel *projectModel, const ReportCriteria &rc)
+{
+    const QDate fromDate = rc.from;
+    const QDate toDate = rc.to;
+    const QString cr = QStringLiteral("\n");
+
+    // Collect data: group events by task UID for the given date range
+    QMap<QString, TaskPeriodData> taskDataMap;
+
+    for (const Event *event : projectModel->eventsModel()->events()) {
+        if (!event->hasEndDate()) {
+            continue; // skip currently running timers
+        }
+
+        const QDate eventDate = event->dtStart().date();
+        if (eventDate < fromDate || eventDate > toDate) {
+            continue;
+        }
+
+        const QString taskUid = event->relatedTo();
+        if (taskUid.isEmpty()) {
+            continue;
+        }
+
+        Task *task = dynamic_cast<Task *>(projectModel->tasksModel()->taskByUID(taskUid));
+        if (!task) {
+            continue;
+        }
+
+        TaskPeriodData &data = taskDataMap[taskUid];
+        if (data.name.isEmpty()) {
+            // Build full task name including parent chain
+            QString fullName = task->name();
+            Task *parent = task->parentTask();
+            while (parent) {
+                fullName = parent->name() + QStringLiteral(" -> ") + fullName;
+                parent = parent->parentTask();
+            }
+            data.name = fullName;
+        }
+
+        const int64_t durationSecs = event->dtEnd().toSecsSinceEpoch() - event->dtStart().toSecsSinceEpoch();
+        if (durationSecs > 0) {
+            data.totalSeconds += durationSecs;
+        }
+
+        // Use only the last comment — earlier entries are previous edit versions
+        const QStringList eventComments = event->comments();
+        if (!eventComments.isEmpty()) {
+            const QString comment = eventComments.last().trimmed();
+            if (!comment.isEmpty()) {
+                data.comments.append({comment, durationSecs > 0 ? durationSecs : 0});
+            }
+        }
+    }
+
+    // Build report string
+    QString report;
+
+    const QString title = i18n("Period Report — %1 – %2",
+                               QLocale().toString(fromDate, QLocale::ShortFormat),
+                               QLocale().toString(toDate, QLocale::ShortFormat));
+    report += title + cr;
+    report += QString(title.length(), QChar::fromLatin1('=')) + cr + cr;
+
+    if (taskDataMap.isEmpty()) {
+        report += i18n("No tasks recorded for this period.") + cr;
+        return report;
+    }
+
+    int64_t grandTotalSeconds = 0;
+
+    for (const TaskPeriodData &data : taskDataMap) {
+        const double minutes = static_cast<double>(data.totalSeconds) / 60.0;
+        report += i18n("Task: %1", data.name) + cr;
+        report += QStringLiteral("  ") + i18n("Time: %1", formatTime(minutes, rc.decimalMinutes)) + cr;
+
+        if (!data.comments.isEmpty()) {
+            report += QStringLiteral("  ") + i18n("Comments:") + cr;
+            for (const CommentEntry &c : data.comments) {
+                const double mins = static_cast<double>(c.seconds) / 60.0;
+                report += QStringLiteral("    - ") + c.text
+                    + QStringLiteral(" [") + formatTime(mins, rc.decimalMinutes) + QStringLiteral("]") + cr;
+            }
+        }
+
+        report += cr;
+        grandTotalSeconds += data.totalSeconds;
+    }
+
+    const double totalMinutes = static_cast<double>(grandTotalSeconds) / 60.0;
+    report += QString(40, QChar::fromLatin1('-')) + cr;
+    report += i18n("Total: %1", formatTime(totalMinutes, rc.decimalMinutes)) + cr;
+
+    return report;
+}

--- a/src/export/periodreport.h
+++ b/src/export/periodreport.h
@@ -1,0 +1,25 @@
+/*
+    SPDX-FileCopyrightText: 2026 KTimeTracker contributors
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef PERIODREPORT_H
+#define PERIODREPORT_H
+
+#include <QString>
+
+#include "base/reportcriteria.h"
+
+class ProjectModel;
+
+/**
+ * Generate a period report as plain text.
+ *
+ * The report lists all tasks that have recorded time in the [rc.from, rc.to]
+ * date range, showing the task name, all associated comments, and the total
+ * time spent. A grand total line is appended at the end.
+ */
+QString exportPeriodReportToString(ProjectModel *projectModel, const ReportCriteria &rc);
+
+#endif // PERIODREPORT_H


### PR DESCRIPTION
Perhaps this change will be useful for the community.
As a freelancer, I missed time-spent reports, so I decided to add them.
Daily detailed reports are available, as well as for a specified period.
It looks like this:

```
Daily Report — Monday, 9 March 2026
===================================

Task: Development -> apiserver -> omnichannel
  Time: 4:50
  Comments:
    - Devel container issue [0:05]
    - Troubleshooting issues with original SMS message templates [1:17]

Task: Conversations -> Meeting
  Time: 0:47

Task: Development -> superserver -> nginx config
  Time: 0:51
  Comments:
    - Performance Tuning Guide [0:51]

----------------------------------------
Total: 5:49
```
